### PR TITLE
misc stuff

### DIFF
--- a/apps/api/Sources/App/PairQL/Order/GetPrintJobExploratoryMetadata.swift
+++ b/apps/api/Sources/App/PairQL/Order/GetPrintJobExploratoryMetadata.swift
@@ -28,7 +28,8 @@ extension GetPrintJobExploratoryMetadata: Resolver {
           state: input.address.state,
           zip: input.address.zip,
           country: input.address.country
-        )
+        ),
+        email: input.email
       )
     } catch PrintJobs.Error.noExploratoryMetadataRetrieved {
       throw context.error(

--- a/apps/api/Sources/App/Services/PrintJobs.swift
+++ b/apps/api/Sources/App/Services/PrintJobs.swift
@@ -69,7 +69,8 @@ enum PrintJobs {
 
   static func getExploratoryMetadata(
     for items: [ExploratoryItem],
-    shippedTo address: ShippingAddress
+    shippedTo address: ShippingAddress,
+    email: EmailAddress
   ) async throws -> ExploratoryMetadata {
     try await withThrowingTaskGroup(of: (
       Lulu.Api.PrintJobCostCalculationsResponse?,
@@ -111,6 +112,7 @@ enum PrintJobs {
                 Address:
 
                 ```
+                email: \(email)
                 "\(JSON.encode(address, .pretty) ?? String(describing: address))"
                 ```
               """)
@@ -138,7 +140,7 @@ enum PrintJobs {
       }
 
       guard let (cheapest, level) = results.first else {
-        Task { await slackError("shipping not possible: \(address)") }
+        Task { await slackError("shipping not possible: \(email), \(address)") }
         throw Error.noExploratoryMetadataRetrieved
       }
 

--- a/apps/api/Tests/AppTests/PrintJobsTests.swift
+++ b/apps/api/Tests/AppTests/PrintJobsTests.swift
@@ -144,7 +144,7 @@ final class PrintJobsTests: AppTestCase {
 
     let meta = try await PrintJobs.getExploratoryMetadata(
       for: [.init(volumes: .init(259), printSize: .m, quantity: 1)],
-      shippedTo: .mock
+      shippedTo: .mock, email: "bob@email.com"
     )
     XCTAssertEqual(meta.creditCardFeeOffset, 88)
     XCTAssertEqual(meta.shipping, 999)
@@ -169,7 +169,7 @@ final class PrintJobsTests: AppTestCase {
 
     let meta = try await PrintJobs.getExploratoryMetadata(
       for: [.init(volumes: .init(259), printSize: .m, quantity: 1)],
-      shippedTo: .mock
+      shippedTo: .mock, email: ""
     )
 
     XCTAssertEqual(meta.shipping, 1094)

--- a/apps/next-evans/components/checkout/hooks.ts
+++ b/apps/next-evans/components/checkout/hooks.ts
@@ -18,9 +18,11 @@ export function useNumCartItems(): [number, (numItems: number) => void, CartStor
 }
 
 export function useCartTotalQuantity(): [number, (qty: number) => void, CartStore] {
-  const [quantity, setQuantity] = useState<number>(store.cart.totalQuantity());
+  const [quantity, setQuantity] = useState<number>(0);
   const onChange = (): void => setQuantity(store.cart.totalQuantity());
   useEffect(() => {
+    // prevent client hydration mismatch from reading cookie on first render
+    setQuantity(store.cart.totalQuantity());
     store.on(`cart:changed`, onChange);
     return () => {
       store.off(`cart:changed`, onChange);

--- a/apps/next-evans/components/checkout/services/CheckoutService.ts
+++ b/apps/next-evans/components/checkout/services/CheckoutService.ts
@@ -130,7 +130,8 @@ export default class CheckoutService {
 
   private createOrderArgs(): Parameters<InstanceType<typeof CheckoutApi>['createOrder']> {
     const { shipping, taxes, ccFeeOffset, fees } = this.metadata;
-    if (!this.cart.address) throw new Error(`Missing address`);
+    if (!this.cart.address) throw new Error(`Missing address in createOrderArgs()`);
+    if (!this.cart.email) throw new Error(`Missing email in createOrderArgs()`);
     const items = this.cart.items
       .filter((i) => i.quantity > 0)
       .map((item): T.CreateOrder.Input['items'][0] => ({
@@ -146,7 +147,7 @@ export default class CheckoutService {
       taxes,
       ccFeeOffset,
       fees,
-      email: this.cart.email ?? ``, // @TODO
+      email: this.cart.email,
       shippingLevel: this.shippingLevel,
       addressName: this.cart.address.name,
       addressStreet: this.cart.address.street,

--- a/apps/next-evans/components/chrome/Chrome.tsx
+++ b/apps/next-evans/components/chrome/Chrome.tsx
@@ -9,6 +9,7 @@ import Nav from './Nav';
 import Slideover from './Slideover';
 import Footer from './Footer';
 import { appReducer, appInitialState, AppDispatch } from '@/lib/app-state';
+import { FIXED_TOPNAV_HEIGHT } from '@/lib/scroll';
 
 interface Props {
   children: React.ReactNode;
@@ -51,7 +52,12 @@ const Chrome: React.FC<Props> = ({ children }) => {
       {itemJustAdded && (
         <PopUnder
           alignRight
-          style={{ position: `fixed`, right: 7, top: 73, zIndex: 1000 }}
+          style={{
+            position: `fixed`,
+            right: 6,
+            top: FIXED_TOPNAV_HEIGHT + 3,
+            zIndex: 1000,
+          }}
           bgColor="flprimary"
         >
           <Dual.P className="text-white px-8 py-4 font-sans antialiased">

--- a/apps/next-evans/components/chrome/Nav.tsx
+++ b/apps/next-evans/components/chrome/Nav.tsx
@@ -42,8 +42,8 @@ const Nav: React.FC<Props> = ({
   return (
     <nav
       className={cx(
-        `h-[70px] pr-[20px] flex bg-white border-gray-300 border-b`,
-        `fixed top-0 z-[49] w-screen`,
+        `h-[70px] pr-[16px] sm:pr-[20px] flex bg-white border-gray-300 border-b`,
+        `fixed top-0 z-[49] w-full`,
         searching &&
           (LANG === `en`
             ? `[&_input]:bg-[rgb(108,49,66,0.05)]`

--- a/apps/next-evans/components/chrome/Nav.tsx
+++ b/apps/next-evans/components/chrome/Nav.tsx
@@ -58,11 +58,12 @@ const Nav: React.FC<Props> = ({
         })}
       />
       <Link
+        href="/"
+        prefetch={false}
         className={cx(`m-0 sm:inline mr-4 sm:mr-0`, {
           'hidden flex-grow-0': searching,
           'flex-grow': !searching,
         })}
-        href="/"
       >
         <Logo
           className={cx(

--- a/apps/next-evans/components/chrome/SlideoverMenu.tsx
+++ b/apps/next-evans/components/chrome/SlideoverMenu.tsx
@@ -112,7 +112,9 @@ const LinkGroup: React.FC<{ links: LinkItem[] }> = ({ links }) => (
             {href.startsWith(`https`) ? (
               <a href={href}>{text}</a>
             ) : (
-              <Link href={href}>{text}</Link>
+              <Link prefetch={false} href={href}>
+                {text}
+              </Link>
             )}
           </li>
         );

--- a/apps/next-evans/components/core/PopUnder.tsx
+++ b/apps/next-evans/components/core/PopUnder.tsx
@@ -25,7 +25,9 @@ const PopUnder: React.FC<Props> = ({
       `bg-${bgColor}`,
       `text-${bgColor}`,
       `rounded-lg shadow-direct relative flex flex-col`,
-      alignRight ? `after:right-[18px]` : `after:left-[calc(50%-10px)]`,
+      alignRight
+        ? `after:right-[19px] sm:after:right-[23px]`
+        : `after:left-[calc(50%-10px)]`,
       `after:w-6 after:h-6 after:bg-${bgColor} after:absolute after:-top-2 after:rotate-45 z-10`,
     )}
   >

--- a/apps/next-evans/components/pages/explore/NewBooksBlock.tsx
+++ b/apps/next-evans/components/pages/explore/NewBooksBlock.tsx
@@ -16,6 +16,7 @@ const NewBooksBlock: React.FC<Props> = ({ books }) => (
     title={t`Recently Added Books`}
     titleEl="h2"
     books={books}
+    sortBy="createdAt"
     withDateBadges
   />
 );


### PR DESCRIPTION
- fixes sorting of recent books on explore page by exposing a `sortBy` prop to customize sorting of `<BookTeaserCards />`
- fixes alignment of cart badge in nav, so that "item was added" popunder is aligned correctly
- ensures emails are sent with order exploratory request (fixes #74)
- disables `prefetch` for links in the sidebar (more detail below)

i did a little preliminary perf comparisons with the existing site using lighthouse, and the next site was downloading a lot of extra javascript, because apparently in production `next/link` prefetches all of the javascript for any link in the viewport (see links below). our slideover nav is in the viewport, and so it's prefetching lots of javascript (including the big "what quakers believed" page, which is a small book packaged as a web page).  setting `prefetch={false}` i believe should prevent this, and still cause prefetching when the link is hovered, which i believe is the behavior we want (and the behavior gatsby has by default). i'm going to test with lighthouse after this deploys (prefetching only works in production).  we may eventually want to go so far as to make our own link wrapper and use it everywhere, so we can disable _all_ viewport based prefetching (or opt in explicitly), but we should probably profile/benchmark before taking that step.

https://github.com/vercel/next.js/discussions/11793
https://nextjs.org/docs/pages/api-reference/components/link