### PR TITLE
evans: tighten up shipping address validation

### DIFF
--- a/apps/evans/components/forms/ShippingAddress.tsx
+++ b/apps/evans/components/forms/ShippingAddress.tsx
@@ -88,7 +88,7 @@ const ShippingAddress: React.FC<Props> = ({
             ? t`Street address is required`
             : t`Must be less than 30 characters`
         }
-        valid={!streetBlurred || (!!street && street.length < 30)}
+        valid={!streetBlurred || (street.trim().length > 0 && street.length < 30)}
         autoComplete="address-line1"
         name="address"
       />
@@ -104,7 +104,7 @@ const ShippingAddress: React.FC<Props> = ({
       <Input
         wrapClassName="md:order-2"
         invalidMsg={t`City is required`}
-        valid={!cityBlurred || !!city}
+        valid={!cityBlurred || city.trim().length > 0}
         onChange={(val) => setCity(val)}
         onFocus={() => setCityBlurred(false)}
         onBlur={() => setCityBlurred(true)}
@@ -116,7 +116,7 @@ const ShippingAddress: React.FC<Props> = ({
       <Input
         wrapClassName="md:order-4"
         invalidMsg={t`State / Province / Region is required`}
-        valid={!stateBlurred || !!state}
+        valid={!stateBlurred || state.trim().length > 0}
         onChange={(val) => setState(val)}
         onFocus={() => setStateBlurred(false)}
         onBlur={() => setStateBlurred(true)}
@@ -128,7 +128,7 @@ const ShippingAddress: React.FC<Props> = ({
       <Input
         wrapClassName="md:order-6"
         invalidMsg={t`ZIP / Postal Code is required`}
-        valid={!zipBlurred || !!zip}
+        valid={!zipBlurred || zip.trim().length > 0}
         onChange={(val) => setZip(val)}
         onFocus={() => setZipBlurred(false)}
         onBlur={() => setZipBlurred(true)}

--- a/apps/evans/components/forms/hooks.ts
+++ b/apps/evans/components/forms/hooks.ts
@@ -47,14 +47,14 @@ export function useAddress(
       country,
     },
     !!(
-      name &&
-      street &&
+      name.trim().length > 0 &&
+      street.trim().length > 0 &&
       street.length < 30 &&
       street2.length < 30 &&
-      city &&
-      state &&
-      zip &&
-      country &&
+      city.trim().length > 0 &&
+      state.trim().length > 0 &&
+      zip.trim().length > 0 &&
+      country.trim().length > 0 &&
       email.includes(`@`)
     ),
   ];


### PR DESCRIPTION
got some errors last night from a user who seemed to be trying to submit an order with an empty street. i'm not sure how she was able to create the request that submitted the empty street, as the form currently prevents submission in that case, but these little tweaks at least fill in a loophole i found while trying to repro: currently all these fields accept an empty string, or a sequence of whitespace only.