### PR TITLE
evans: persist audio player position

### DIFF
--- a/apps/evans/components/pages/document/ListenBlock.tsx
+++ b/apps/evans/components/pages/document/ListenBlock.tsx
@@ -65,6 +65,8 @@ const ListenBlock: React.FC<Props> = ({ tracks, ...props }) => {
         </h3>
         <div className="mx-4 xs:mx-6 sm:mb-8 lg:ml-0">
           <AudioPlayer
+            // key important to reset player when switching between books
+            key={tracks.map((t) => t.mp3Url[quality]).join(`|`)}
             tracks={tracks.map((track) => ({
               title: track.title,
               duration: track.duration,


### PR DESCRIPTION
closes: https://github.com/friends-library/dev/issues/125

I think it handles when the stored info is bad (non-existent track index, too big currentTime) and I checked it, but there's probably a case that I didn't think about.