### PR TITLE
admin: link to commercial invoice from order view

### DIFF
--- a/apps/admin/src/components/orders/ViewOrder.tsx
+++ b/apps/admin/src/components/orders/ViewOrder.tsx
@@ -41,6 +41,18 @@ export const ViewOrder: React.FC<Props> = ({ order }) => (
             </li>
             <li>{order.address.country}</li>
           </ul>
+          <div className="mt-2">
+            <a
+              className="border-b border-dotted text-flblue subtle-text"
+              href={`https://www.${
+                order.lang === `es` ? `bibliotecadelosamigos.org` : `friendslibrary.com`
+              }/order/${order.id}/invoice`}
+              target="_blank"
+              rel="noreferrer"
+            >
+              View invoice
+            </a>
+          </div>
         </div>
         {order.source !== `internal` ? (
           <div>


### PR DESCRIPTION
## Summary
- Adds a **View invoice** link under the personal info section of the admin order page (left column), pointing to the language-appropriate evans invoice route added in #216.
- Uses `order.lang` to pick `friendslibrary.com` vs `bibliotecadelosamigos.org`.

## Test plan
- [ ] Open an English order in admin → link points to `https://www.friendslibrary.com/order/<uuid>/invoice` and opens the invoice page.
- [ ] Open a Spanish order in admin → link points to `https://www.bibliotecadelosamigos.org/order/<uuid>/invoice` and opens the (translated) invoice page.