### PR TITLE
api,evans: tighten email validation to reject whitespace/malformed addresses

### DIFF
--- a/apps/api/Sources/App/PairQL/Evans/SubscribeToNarrowPath.swift
+++ b/apps/api/Sources/App/PairQL/Evans/SubscribeToNarrowPath.swift
@@ -20,13 +20,14 @@ struct SubscribeToNarrowPath: Pair {
 extension SubscribeToNarrowPath: Resolver {
   static func resolve(with input: Input, in context: Context) async throws -> Output {
     try await checkSpam(input)
+    let email = try input.email.validated(in: context)
 
     let existing = try? await NPSubscriber.query()
-      .where(.email == input.email.rawValue.lowercased())
+      .where(.email == email.rawValue.lowercased())
       .where(.lang == input.lang)
       .first(in: context.db)
     if existing != nil {
-      await slackError("NP subscribe duplicate email error: `\(input.email)`")
+      await slackError("NP subscribe duplicate email error: `\(email)`")
       throw Abort(.badRequest, reason: "Email already subscribed")
     }
 
@@ -35,7 +36,7 @@ extension SubscribeToNarrowPath: Resolver {
     try await context.db.create(NPSubscriber(
       token: token,
       mixedQuotes: input.mixedQuotes,
-      email: input.email.rawValue.lowercased(),
+      email: email.rawValue.lowercased(),
       lang: input.lang,
     ))
 
@@ -43,7 +44,7 @@ extension SubscribeToNarrowPath: Resolver {
       await slackInfo(
         """
         *New Narrow Path subscriber:*
-        _Email:_ \(input.email.rawValue.lowercased())
+        _Email:_ \(email.rawValue.lowercased())
         _Language:_ \(input.lang == .en ? "English" : "Spanish")
         _Mixed quotes:_ \(input.mixedQuotes ? "yes" : "no")
         """,
@@ -52,9 +53,9 @@ extension SubscribeToNarrowPath: Resolver {
 
     switch input.lang {
     case .en:
-      try await sendEnglishConfirm(to: input.email, confirming: token)
+      try await sendEnglishConfirm(to: email, confirming: token)
     case .es:
-      try await sendSpanishConfirm(to: input.email, confirming: token)
+      try await sendSpanishConfirm(to: email, confirming: token)
     }
 
     return .success

--- a/apps/api/Sources/App/PairQL/Order/CreateFreeOrderRequest.swift
+++ b/apps/api/Sources/App/PairQL/Order/CreateFreeOrderRequest.swift
@@ -24,7 +24,7 @@ extension CreateFreeOrderRequest: Resolver {
   static func resolve(with input: Input, in context: Context) async throws -> Output {
     let order = try await context.db.create(FreeOrderRequest(
       name: input.name,
-      email: input.email,
+      email: input.email.validated(in: context),
       requestedBooks: input.requestedBooks,
       aboutRequester: input.aboutRequester,
       addressStreet: input.addressStreet,

--- a/apps/api/Sources/App/PairQL/Order/CreateOrder.swift
+++ b/apps/api/Sources/App/PairQL/Order/CreateOrder.swift
@@ -41,6 +41,8 @@ struct CreateOrder: Pair {
 
 extension CreateOrder: Resolver {
   static func resolve(with input: Input, in context: Context) async throws -> Output {
+    var input = input
+    input.email = try input.email.validated(in: context)
     let order = Order(input)
     let items = input.items.map { OrderItem($0, orderId: order.id) }
     try await context.db.create(order)

--- a/apps/api/Sources/App/Types/EmailAddress.swift
+++ b/apps/api/Sources/App/Types/EmailAddress.swift
@@ -1,0 +1,17 @@
+import Foundation
+
+extension EmailAddress {
+  /// Trims whitespace and rejects malformed addresses — catches typos and stray
+  /// whitespace, not a full RFC 5322 validator.
+  func validated(in context: some ResolverContext) throws -> EmailAddress {
+    let trimmed = rawValue.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard trimmed.match(#"^\S+@\S+\.\S+$"#) else {
+      throw context.error(
+        id: "b6f2a1c4",
+        type: .badRequest,
+        detail: "Invalid email address `\(rawValue)`",
+      )
+    }
+    return EmailAddress(rawValue: trimmed)
+  }
+}

--- a/apps/api/Tests/AppTests/Mocks/FreeOrderRequest+Mocks.swift
+++ b/apps/api/Tests/AppTests/Mocks/FreeOrderRequest+Mocks.swift
@@ -38,7 +38,7 @@ extension FreeOrderRequest {
   static var random: FreeOrderRequest {
     FreeOrderRequest(
       name: "@random".random,
-      email: .init(rawValue: "@random".random),
+      email: .init(rawValue: "random-\(Int.random)@example.com"),
       requestedBooks: "@random".random,
       aboutRequester: "@random".random,
       addressStreet: "@random".random,

--- a/apps/api/Tests/AppTests/Mocks/Order+Mocks.swift
+++ b/apps/api/Tests/AppTests/Mocks/Order+Mocks.swift
@@ -59,7 +59,7 @@ extension Order {
       ccFeeOffset: .init(rawValue: Int.random),
       shipping: .init(rawValue: Int.random),
       shippingLevel: ShippingLevel.allCases.shuffled().first!,
-      email: .init(rawValue: "@random".random),
+      email: .init(rawValue: "random-\(Int.random)@example.com"),
       addressName: "@random".random,
       addressStreet: "@random".random,
       addressStreet2: Bool.random() ? "@random".random : nil,

--- a/apps/api/Tests/AppTests/Orders/Order+ResolverTests.swift
+++ b/apps/api/Tests/AppTests/Orders/Order+ResolverTests.swift
@@ -115,6 +115,25 @@ final class OrderResolverTests: AppTestCase, @unchecked Sendable {
     expect(retrieved.addressState).toEqual("TX") // <-- capitalized
   }
 
+  func testCreateOrderRejectsEmailContainingSpace() async throws {
+    var (input, _) = try await orderSetup()
+    input.email = .init(rawValue: "john doe@example.com")
+
+    try await expectErrorFrom {
+      try await CreateOrder.resolve(with: input, in: .mock)
+    }.toContain("badRequest")
+  }
+
+  func testCreateOrderTrimsSurroundingWhitespaceFromEmail() async throws {
+    var (input, _) = try await orderSetup()
+    input.email = .init(rawValue: "  john@example.com  ")
+
+    let output = try await CreateOrder.resolve(with: input, in: .mock)
+
+    let retrieved = try await self.db.find(output)
+    expect(retrieved.email).toEqual("john@example.com")
+  }
+
   func testCreateOrderWithFreeRequestId() async throws {
     let req = try await self.db.create(FreeOrderRequest.random)
     var (input, _) = try await orderSetup()

--- a/apps/api/Tests/AppTests/PairQL/SubscribeToNarrowPathTests.swift
+++ b/apps/api/Tests/AppTests/PairQL/SubscribeToNarrowPathTests.swift
@@ -172,6 +172,24 @@ final class SubscribeToNarrowPathTests: AppTestCase, @unchecked Sendable {
     }
   }
 
+  func testRejectsEmailContainingSpace() async throws {
+    try await withDependencies {
+      $0.cloudflareClient = .init(verifyTurnstileToken: { _ in .success })
+    } operation: {
+      try await expectErrorFrom {
+        try await SubscribeToNarrowPath.resolve(
+          with: .init(
+            email: .init(rawValue: "john doe@example.com"),
+            lang: .en,
+            mixedQuotes: false,
+            turnstileToken: "turnstile-token-value",
+          ),
+          in: .mock,
+        )
+      }.toContain("Invalid email address")
+    }
+  }
+
   func testSpamRejectionFromCloudflareChallenge() async throws {
     var quote = NPQuote.mock
     quote.lang = .en

--- a/apps/evans/components/forms/ShippingAddress.tsx
+++ b/apps/evans/components/forms/ShippingAddress.tsx
@@ -3,6 +3,7 @@ import cx from 'classnames';
 import { t } from '@friends-library/locale';
 import { COUNTRIES, TAX_ID_COUNTRIES, recipientTaxIdType } from '@friends-library/lulu';
 import Input from './Input';
+import { isValidEmail } from './validation';
 
 export interface Props {
   email: string;
@@ -73,7 +74,7 @@ const ShippingAddress: React.FC<Props> = ({
       <Input
         wrapClassName="md:order-3"
         invalidMsg={email ? t`Valid email is required` : t`Email is required`}
-        valid={!emailBlurred || !!email.match(/^\S+@\S+$/)}
+        valid={!emailBlurred || isValidEmail(email)}
         onChange={(val) => setEmail(val)}
         onFocus={() => setEmailBlurred(false)}
         onBlur={() => setEmailBlurred(true)}

--- a/apps/evans/components/forms/hooks.ts
+++ b/apps/evans/components/forms/hooks.ts
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import { TAX_ID_COUNTRIES } from '@friends-library/lulu';
 import type { AddressWithEmail } from '@/lib/types';
 import type { Props as AddressProps } from './ShippingAddress';
+import { isValidEmail } from './validation';
 
 export function useAddress(
   initial: Partial<AddressWithEmail>,
@@ -43,7 +44,7 @@ export function useAddress(
       setRecipientTaxId,
     },
     {
-      email,
+      email: email.trim(),
       name,
       street,
       street2,
@@ -62,7 +63,7 @@ export function useAddress(
       state.trim().length > 0 &&
       zip.trim().length > 0 &&
       country.trim().length > 0 &&
-      email.includes(`@`) &&
+      isValidEmail(email) &&
       (!TAX_ID_COUNTRIES.includes(country) || recipientTaxId.trim().length > 0)
     ),
   ];

--- a/apps/evans/components/forms/validation.ts
+++ b/apps/evans/components/forms/validation.ts
@@ -1,0 +1,3 @@
+export function isValidEmail(email: string): boolean {
+  return /^\S+@\S+\.\S+$/.test(email.trim());
+}


### PR DESCRIPTION
had an order come through prod with a space in the email address. turned out the checkout's submit gate was only checking for an `@`, and the api did zero validation, so it sailed right through and got stored/emailed as-is.

tightened the checkout gate to trim + do a basic format check (shared now with the visual field validation so they finally agree), and added a validating `EmailAddress` on the api that trims and rejects garbage, wired into create order, free order request, and narrow path subscribe. left the contact form alone since its email is only used as a reply-to. tests cover the space case. note i didn't go full rfc 5322 on purpose — goal is catching typos/stray whitespace, not rejecting exotic-but-valid forms.